### PR TITLE
Use shebang recipes for php and compile-toy

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,16 +1,20 @@
 compile-toy:
-	cd tests && \
-		rustc --target wasm32-unknown-unknown  -O --crate-type=cdylib toy.rs -o toy.raw.wasm && \
-		wasm-gc toy.raw.wasm toy.wasm && \
-		rm toy.raw.wasm
+	#!/usr/bin/env bash
+	set -euo pipefail
+	cd tests
+	rustc --target wasm32-unknown-unknown  -O --crate-type=cdylib toy.rs -o toy.raw.wasm
+	wasm-gc toy.raw.wasm toy.wasm
+	rm toy.raw.wasm
 
 php:
-	cd extension && \
-		PHP_PREFIX_BIN=$(php-config --prefix)/bin && \
-		$PHP_PREFIX_BIN/phpize --clean && \
-		$PHP_PREFIX_BIN/phpize && \
-		./configure --with-php-config=$PHP_PREFIX_BIN/php-config && \
-		make install
+	#!/usr/bin/env bash
+	set -euo pipefail
+	cd extension
+	PHP_PREFIX_BIN=$(php-config --prefix)/bin
+	$PHP_PREFIX_BIN/phpize --clean
+	$PHP_PREFIX_BIN/phpize
+	./configure --with-php-config=$PHP_PREFIX_BIN/php-config
+	make install
 
 c:
 	clang \


### PR DESCRIPTION
Hi there!

I sometimes look around at justfiles in the wild, and happened upon yours.

If you put a shebang line at the beginning of a recipe, just will extract it into a file and run it as a script, as opposed to running each line in a fresh shell. This makes cd-ing and setting variables much nicer. If you're using bash, you should remember to include `set -euo pipefail` at the beginning of your recipes. `-e` causes bash to exit if a command fails, `-u` exits if an undefined variable is evaluated, and `-o pipefail` is like `-e`, but applies to commands in the middle of a pipeline.

Please note that I didn't run the changed version, so please double check that they're correct if you decide to merge this PR.

Thank you for using Just!